### PR TITLE
Populate all `element-array-ephys` tables in automated pipeline

### DIFF
--- a/u19_pipeline/automatic_job/ephys_element_populate.py
+++ b/u19_pipeline/automatic_job/ephys_element_populate.py
@@ -16,7 +16,8 @@ def run(display_progress=True, reserve_jobs=False, suppress_errors=False):
         recording_id, fragment_number, recording_process_pre_path = \
                                 (recording_process.Processing & key).fetch1(
                                                 'recording_id', 
-                                                'fragment_number', 'recording_process_pre_path')
+                                                'fragment_number',
+                                                'recording_process_pre_path')
     
         precluster_param_list_id = (recording_process.Processing.EphysParams & \
                                                 key).fetch1('precluster_param_list_id')
@@ -39,11 +40,13 @@ def run(display_progress=True, reserve_jobs=False, suppress_errors=False):
         recording_id, fragment_number, recording_process_post_path = \
                                 (recording_process.Processing & key).fetch1(
                                                 'recording_id', 
-                                                'fragment_number', 'recording_process_post_path')
+                                                'fragment_number', 
+                                                'recording_process_post_path')
 
         precluster_param_list_id, cluster_paramset_idx = \
                             (recording_process.Processing.EphysParams & key).fetch1(
-                                                        'precluster_param_list_id', 'cluster_paramset_idx')
+                                                        'precluster_param_list_id', 
+                                                        'cluster_paramset_idx')
 
         ephys_element.ClusteringTask.insert1(
             dict(recording_id=recording_id, 

--- a/u19_pipeline/automatic_job/ephys_element_populate.py
+++ b/u19_pipeline/automatic_job/ephys_element_populate.py
@@ -9,8 +9,8 @@ def run(display_progress=True, reserve_jobs=False, suppress_errors=False):
 
     ephys_element.EphysRecording.populate(**populate_settings)
 
-    for key in (recording_process.Processing * recording.Recording & \
-                            dict(recording_modality='electrophysiology', \
+    for key in (recording_process.Processing * recording.Recording & 
+                            dict(recording_modality='electrophysiology', 
                                  status_processing_id=7)).fetch('KEY'):
 
         recording_id, fragment_number, recording_process_pre_path = \
@@ -19,7 +19,7 @@ def run(display_progress=True, reserve_jobs=False, suppress_errors=False):
                                                 'fragment_number',
                                                 'recording_process_pre_path')
     
-        precluster_param_list_id = (recording_process.Processing.EphysParams & \
+        precluster_param_list_id = (recording_process.Processing.EphysParams & 
                                                 key).fetch1('precluster_param_list_id')
         
         ephys_element.PreClusterTask.insert1(
@@ -33,8 +33,8 @@ def run(display_progress=True, reserve_jobs=False, suppress_errors=False):
 
     ephys_element.LFP.populate(**populate_settings)
 
-    for key in (recording_process.Processing * recording.Recording & \
-                            dict(recording_modality='electrophysiology', \
+    for key in (recording_process.Processing * recording.Recording & 
+                            dict(recording_modality='electrophysiology', 
                                  status_processing_id=7)).fetch('KEY'):
 
         recording_id, fragment_number, recording_process_post_path = \

--- a/u19_pipeline/automatic_job/ephys_element_populate.py
+++ b/u19_pipeline/automatic_job/ephys_element_populate.py
@@ -1,25 +1,67 @@
-from u19_pipeline.ephys_element import ephys_element
+from u19_pipeline.ephys_pipeline import ephys_element
+from u19_pipeline import recording, recording_process
 
+def run(display_progress=True, reserve_jobs=False, suppress_errors=False):
 
-def populate(display_progress=True):
+    populate_settings = {'display_progress': display_progress, 
+                         'reserve_jobs': reserve_jobs, 
+                         'suppress_errors': suppress_errors}
 
-    populate_settings = {'display_progress': display_progress, 'reserve_jobs': False, 'suppress_errors': False}
-
-    print('\n---- Populate ephys.EphysRecording ----')
     ephys_element.EphysRecording.populate(**populate_settings)
 
-    print('\n---- Populate ephys.LFP ----')
+    for key in (recording_process.Processing * recording.Recording & \
+                            dict(recording_modality='electrophysiology', \
+                                 status_processing_id=7)).fetch('KEY'):
+
+        recording_id, fragment_number, recording_process_pre_path = \
+                                (recording_process.Processing & key).fetch1(
+                                                'recording_id', 
+                                                'fragment_number', 'recording_process_pre_path')
+    
+        precluster_param_list_id = (recording_process.Processing.EphysParams & \
+                                                key).fetch1('precluster_param_list_id')
+        
+        ephys_element.PreClusterTask.insert1(
+                                dict(recording_id=recording_id,
+                                     insertion_number=fragment_number,
+                                     precluster_param_list_id=precluster_param_list_id,
+                                     precluster_output_dir=recording_process_pre_path,
+                                     task_mode='load'))
+
+    ephys_element.PreCluster.populate(**populate_settings)
+
     ephys_element.LFP.populate(**populate_settings)
 
-    print('\n---- Populate ephys.Clustering ----')
+    for key in (recording_process.Processing * recording.Recording & \
+                            dict(recording_modality='electrophysiology', \
+                                 status_processing_id=7)).fetch('KEY'):
+
+        recording_id, fragment_number, recording_process_post_path = \
+                                (recording_process.Processing & key).fetch1(
+                                                'recording_id', 
+                                                'fragment_number', 'recording_process_post_path')
+
+        precluster_param_list_id, cluster_paramset_idx = \
+                            (recording_process.Processing.EphysParams & key).fetch1(
+                                                        'precluster_param_list_id', 'cluster_paramset_idx')
+
+        ephys_element.ClusteringTask.insert1(
+            dict(recording_id=recording_id, 
+                 insertion_number=fragment_number, 
+                 precluster_param_list_id=precluster_param_list_id,
+                 paramset_idx=cluster_paramset_idx,
+                 clustering_output_dir=recording_process_post_path+'/kilosort_output',
+                 task_mode='load'))
+
     ephys_element.Clustering.populate(**populate_settings)
 
-    print('\n---- Populate ephys.CuratedClustering ----')
+    for key in (ephys_element.Clustering - ephys_element.Curation).fetch('KEY'):
+        ephys_element.Curation().create1_from_clustering_task(key)
+
     ephys_element.CuratedClustering.populate(**populate_settings)
 
-    print('\n---- Populate ephys.Waveform ----')
-    ephys_element.Waveform.populate(**populate_settings)
+    ephys_element.WaveformSet.populate(**populate_settings)
 
 
 if __name__ == '__main__':
-    populate()
+    run()

--- a/u19_pipeline/ephys_sync.py
+++ b/u19_pipeline/ephys_sync.py
@@ -3,8 +3,7 @@ import pathlib
 import numpy as np
 
 from u19_pipeline import behavior
-from u19_pipeline.ephys_pipeline import *
-from u19_pipeline.ephys_pipeline import get_session_directory
+from u19_pipeline.ephys_pipeline import ephys_element, get_session_directory
 
 import u19_pipeline.utils.DemoReadSGLXData.readSGLX as readSGLX
 import u19_pipeline.utils.ephys_utils as ephys_utils

--- a/u19_pipeline/recording_process.py
+++ b/u19_pipeline/recording_process.py
@@ -47,7 +47,7 @@ class Processing(dj.Manual):
           -> master
           ---
           -> ephys_element.PreClusterParamList
-          -> ephys_element.ClusteringParamSet
+          -> ephys_element.ClusteringParamSet.proj(cluster_paramset_idx='paramset_idx')
           """
 
      class ImagingParams(dj.Part):


### PR DESCRIPTION
- Set `task_mode=load` for all entries of the `PreClusterTask` table.  This shouldn't make a difference for the actual results stored in the database, but I need to figure out how to handle the case of `task_mode=none`.
- Assumes processed data is in a `kilosort_output` directory.  There are some cases with two directories (`kilosort_output`, `kilosort2_output`).  If we will have two directories in production then I will have to update this script to handle the latter case.  Should we hard code the `kilosort_output` directory, or set as an argument of `run()`?
- I am currently working through a `KeyError` in the Kilosort reader when populating an entry in the `CuratedClustering` table , but this shouldn't be a blocker for this pull request.