### PR TITLE
Set `task_mode` to `none` and `load` for `PreClusterTask` entries

### DIFF
--- a/u19_pipeline/automatic_job/ephys_element_populate.py
+++ b/u19_pipeline/automatic_job/ephys_element_populate.py
@@ -26,7 +26,8 @@ def run(display_progress=True, reserve_jobs=False, suppress_errors=False):
                                 dict(precluster_param_list_id=precluster_param_list_id)
                                ).fetch('paramset_idx')
 
-        if len(precluster_paramsets)==1 and precluster_paramsets[0]==None:
+        if len(precluster_paramsets)==0 or \
+           (len(precluster_paramsets)==1 and precluster_paramsets[0]==None):
             task_mode = 'none'
         else:
             task_mode = 'load'

--- a/u19_pipeline/automatic_job/ephys_element_populate.py
+++ b/u19_pipeline/automatic_job/ephys_element_populate.py
@@ -22,12 +22,21 @@ def run(display_progress=True, reserve_jobs=False, suppress_errors=False):
         precluster_param_list_id = (recording_process.Processing.EphysParams & 
                                                 key).fetch1('precluster_param_list_id')
         
+        precluster_paramsets = (ephys_element.PreClusterParamList.ParamOrder() & 
+                                dict(precluster_param_list_id=precluster_param_list_id)
+                               ).fetch('paramset_idx')
+
+        if len(precluster_paramsets)==1 and precluster_paramsets[0]==None:
+            task_mode = 'none'
+        else:
+            task_mode = 'load'
+
         ephys_element.PreClusterTask.insert1(
                                 dict(recording_id=recording_id,
                                      insertion_number=fragment_number,
                                      precluster_param_list_id=precluster_param_list_id,
                                      precluster_output_dir=recording_process_pre_path,
-                                     task_mode='load'))
+                                     task_mode=task_mode))
 
     ephys_element.PreCluster.populate(**populate_settings)
 


### PR DESCRIPTION
- When no pre-processing is performed on the data set (as defined by the entries in `ephys_element.PreClusterParamList.ParamOrder`) then `task_mode=none`.  Else, pre-processing is performed and `task_mode=load`.